### PR TITLE
Increase FIFO line length so super long YouTube URLs can be played

### DIFF
--- a/omxd.h
+++ b/omxd.h
@@ -1,7 +1,7 @@
 #ifndef OMXD_H
 #define OMXD_H
 /* (c) SZABO Gergely <szg@subogero.com>, license GNU GPL v2 */
-#define LINE_LENGTH 512
+#define LINE_LENGTH 1024 
 #define LINE_MAX (LINE_LENGTH - 1)
 
 #define OMX_CMDS "frFRpkoms-+"


### PR DESCRIPTION
A line length of 512 is not enough to add YouTube video URLs (the ones that start with <blah>.googlevideo.com). A test of mine was ~600 characters.

Increased it to 1024 for extra headroom. Segfaults aren't fun :stuck_out_tongue: 