### PR TITLE
add commands to switch to previous audio/subtitles stream

### DIFF
--- a/README
+++ b/README
@@ -63,8 +63,10 @@ Other commands control the running omxplayer instance.
  p	play/pause
  P	pause playlist, stop omxplayer
  k	next audio stream
+ K	previous audio stream
  o	next chapter
  m	next subtitle stream
+ M	previous subtitle stream
  s	toggle subtitles
  -	volume down
  +	volume up

--- a/omxd.h
+++ b/omxd.h
@@ -4,7 +4,7 @@
 #define LINE_LENGTH 1024 
 #define LINE_MAX (LINE_LENGTH - 1)
 
-#define OMX_CMDS "frFRpkoms-+"
+#define OMX_CMDS "frFRpkKomMs-+"
 #define VOL_CMDS "-+"
 #define LIST_CMDS "iaAIHJL.hjnNdDxXgule"
 #define STOP_CMDS "P"

--- a/player.c
+++ b/player.c
@@ -157,6 +157,10 @@ void player_cmd(struct player *this, char *cmd)
 		cmd = "\033[C";
 	else if (*cmd == 'r')
 		cmd = "\033[D";
+	else if (*cmd == 'M')
+		cmd = "n";
+	else if (*cmd == 'K')
+		cmd = "j";
 	writestr(this->wpipe, cmd);
 	LOG(0, "player_cmd: Send %s to omxplayer PID/fd %d/%d\n",
 		cmd, this->pid, this->wpipe);


### PR DESCRIPTION
Currently when I switch audio or subtitles streams and get to the last, I always stuck on it and do not have any option to get back. Since command 'n' and 'j' are already in use, I added new commands to switch to previous audio/subtitle stream. 